### PR TITLE
#4 千葉市版検索条件変更対応(保育園)

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,56 +90,40 @@
             <form>
                 <div style="padding:10px 20px;">
                     <h3>保育施設 絞り込み</h3>
-                    <legend>認可保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="ninkaOpenTime" class="select">開園</label>
-                        <select id="ninkaOpenTime" class="filtersb">
+                        <label for="OpenTime" class="select">開園</label>
+                        <select id="OpenTime" class="filtersb">
                             <option value="">開園</option>
-                            <option value="7">7:00</option>
-                        </select>
-                        <label for="ninkaCloseTime" class="select">終園</label>
-                        <select id="ninkaCloseTime" class="filtersb">
-                            <option value="">終園</option>
-                            <option value="18">18:00以降</option>
-                            <option value="19">19:00以降</option>
-                            <option value="20">20:00以降</option>
-                            <option value="22">22:00以降</option>
-                            <option value="24">00:00</option>
-                        </select>
-                    </fieldset>
-                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="ninkaIchijiHoiku">一時保育</label>
-                        <input type="checkbox" id="ninkaIchijiHoiku" class="filtercb">
-                        <label for="ninkaYakan">夜間</label>
-                        <input type="checkbox" id="ninkaYakan" class="filtercb">
-                        <label for="ninkaKyujitu">休日</label>
-                        <input type="checkbox" id="ninkaKyujitu" class="filtercb">
-                    </fieldset>
-                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="ninkaVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
-                        <input type="checkbox" id="ninkaVacancy" class="filtercb">
-                    </fieldset>
-                    <legend>認可外保育園</legend>
-                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="ninkagaiOpenTime" class="select">開園</label>
-                        <select id="ninkagaiOpenTime" class="filtersb">
-                            <option value="">開園</option>
-                            <option value="7:00">7:00</option>
+                            <option value="7:00">7:00以前</option>
                             <option value="7:30">7:30以前</option>
                             <option value="7:45">7:45以前</option>
                             <option value="8:00">8:00以前</option>
                         </select>
-                        <label for="ninkagaiCloseTime" class="select">終園</label>
-                        <select id="ninkagaiCloseTime" class="filtersb">
+                        <label for="CloseTime" class="select">終園</label>
+                        <select id="CloseTime" class="filtersb">
                             <option value="">終園</option>
-                            <option value="18">18:00以降</option>
-                            <option value="19">19:00以降</option>
-                            <option value="20">20:00以降</option>
-                            <option value="22">22:00以降</option>
-                            <option value="27">03:00</option>
+                            <option value="18:00">18:00以降</option>
+                            <option value="19:00">19:00以降</option>
+                            <option value="20:00">20:00以降</option>
+                            <option value="22:00">22:00以降</option>
+                            <option value="23:00">23:00以降</option>
+                            <option value="24:00">00:00以降</option>
+                            <option value="27:00">03:00以降</option>
                         </select>
-                        <label for="ninkagai24H">24時間</label>
-                        <input type="checkbox" id="ninkagai24H" class="filtercb">
+                        <label for="24H">24時間</label>
+                        <input type="checkbox" id="24H" class="filtercb">
+                    </fieldset>
+                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+                        <label for="IchijiHoiku">一時保育</label>
+                        <input type="checkbox" id="IchijiHoiku" class="filtercb">
+                        <label for="Yakan">夜間</label>
+                        <input type="checkbox" id="Yakan" class="filtercb">
+                        <label for="Kyujitu">休日</label>
+                        <input type="checkbox" id="Kyujitu" class="filtercb">
+                    </fieldset>
+                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+                        <label for="Vacancy">空きあり（試用版。最新の空き状況ではありません）</label>
+                        <input type="checkbox" id="Vacancy" class="filtercb">
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <a href="#" data-rel="back" id="filterApply" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-check">条件適用</a>

--- a/js/facilityfilter.js
+++ b/js/facilityfilter.js
@@ -18,21 +18,13 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     };
     // console.log("getFilteredFeaturesGeoJson");
 
-    // 認可保育園の検索元データを取得
-    var ninkaFeatures = [];
+    // 保育園の検索元データを取得
+    var hoikuenFeatures = [];
     _features = nurseryFacilities.features.filter(function (item,idx) {
             var type = item.properties['種別'] ? item.properties['種別'] : item.properties['Type'];
-            if(type == "認可保育所") return true;
+            if(type == "認可保育所" || type == "認可外") return true;
         });
-    Array.prototype.push.apply(ninkaFeatures, _features);
-
-    // 認可外保育園の検索元データを取得
-    var ninkagaiFeatures = [];
-    _features = nurseryFacilities.features.filter(function (item,idx) {
-            var type = item.properties['種別'] ? item.properties['種別'] : item.properties['Type'];
-            if(type == "認可外") return true;
-        });
-    Array.prototype.push.apply(ninkagaiFeatures, _features);
+    Array.prototype.push.apply(hoikuenFeatures, _features);
 
     // 幼稚園の検索元データを取得
     var youchienFeatures = [];
@@ -43,164 +35,97 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     Array.prototype.push.apply(youchienFeatures, _features);
 
     // ----------------------------------------------------------------------
-    // 認可保育所向けフィルター
+    // 保育園向けフィルター
     // ----------------------------------------------------------------------
-    // 認可保育所：開園時間
+    // 開園時間
     // console.log("[before]ninkaFeatures length:", ninkaFeatures.length);
-    if(conditions['ninkaOpenTime']) {
+    if(conditions['OpenTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _time = conditions['ninkaOpenTime'] + ":00";
+                var _time = conditions['OpenTime'];
                 var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
-                if(open == _time) {
+                if(open <= _time) {
                     return true;
                 }
             };
             return f(item,idx);
         };
-        ninkaFeatures = ninkaFeatures.filter(filterfunc);
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
-    // 認可保育所：終園時間
-    if(conditions['ninkaCloseTime']) {
+    // 終園時間
+    if(conditions['CloseTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                switch(conditions['ninkaCloseTime']) {
-                    case "18":
-                        checkAry = ["18:00","19:00","20:00","22:00","0:00"];
-                        break;
-                    case "19":
-                        checkAry = ["19:00","20:00","22:00","0:00"];
-                        break;
-                    case "20":
-                        checkAry = ["20:00","22:00","0:00"];
-                        break;
-                    case "22":
-                        checkAry = ["22:00","0:00"];
-                        break;
-                    case "24":
-                        checkAry = ["0:00"];
-                        break;
-                }
+                var _time = conditions['CloseTime'];
                 var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
-                if($.inArray(close, checkAry) >= 0) {
+
+                // 終園時間が0時or翌日の場合は、24時間プラス
+                if(close == '0:00' || close.substr(0,1) == '翌') {
+                    var index = close.indexOf('：');
+                    var hour = Number(close.substr(1,index-1)) + 24;
+                    var minute = close.substr(index+1);
+                    close = hour + ':' + minute;
+                }
+
+                if(close >= _time) {
                     return true;
                 }
             };
             return f(item,idx);
         };
-
-        ninkaFeatures = ninkaFeatures.filter(filterfunc);
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
-    // 認可保育所：一時
-    if(conditions['ninkaIchijiHoiku']) {
+    // 一時保育
+    if(conditions['IchijiHoiku']) {
         filterfunc = function (item,idx) {
             var temp = item.properties['一時'] ? item.properties['一時'] : item.properties['Temp'];
             if(temp === 'Y') {
                 return true;
             }
         };
-        ninkaFeatures = ninkaFeatures.filter(filterfunc);
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
-    // 認可保育所：夜間
-    if(conditions['ninkaYakan']) {
+    // 夜間
+    if(conditions['Yakan']) {
         filterfunc = function (item,idx) {
             var night = item.properties['夜間'] ? item.properties['夜間'] : item.properties['Night'];
             if(night === 'Y') {
                 return true;
             }
         };
-        ninkaFeatures = ninkaFeatures.filter(filterfunc);
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
-    // 認可保育所：休日
-    if(conditions['ninkaKyujitu']) {
+    // 休日
+    if(conditions['Kyujitu']) {
         filterfunc = function (item,idx) {
             var holiday = item.properties['休日'] ? item.properties['休日'] : item.properties['Holiday'];
             if(holiday === 'Y') {
                 return true;
             }
         };
-        ninkaFeatures = ninkaFeatures.filter(filterfunc);
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
-    if(conditions['ninkaVacancy']) {
+    // 空き状況
+    if(conditions['Vacancy']) {
         filterfunc = function (item,idx) {
             var vacancy = item.properties['Vacancy'] ? item.properties['Vacancy'] : item.properties['Vacancy'];
             if(vacancy === 'Y') {
                 return true;
             }
         };
-        ninkaFeatures = ninkaFeatures.filter(filterfunc);
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
     // console.log("[after]ninkaFeatures length:", ninkaFeatures.length);
 
-    // ----------------------------------------------------------------------
-    // 認可外保育所向けフィルター
-    // ----------------------------------------------------------------------
-    // 認可外：開園時間
-    // console.log("[before]ninkagaiFeatures length:", ninkagaiFeatures.length);
-    if(conditions['ninkagaiOpenTime']) {
-        filterfunc = function (item, idx) {
-            f = function (item,idx) {
-                var _time = conditions['ninkagaiOpenTime'];
-                var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
-                if(open == _time) {
-                    return true;
-                }
-            };
-            return f(item,idx);
-        };
-        ninkagaiFeatures = ninkagaiFeatures.filter(filterfunc);
-    }
-    // 認可外：終園時間
-    if(conditions['ninkagaiCloseTime']) {
-        filterfunc = function (item, idx) {
-            f = function (item,idx) {
-                checkAry = [];
-                switch(conditions['ninkagaiCloseTime']) {
-                    case "18":
-                        checkAry = ["18:00","19:00","19:30","19:45","20:00","20:30","22:00","23:00","3:00"];
-                        break;
-                    case "19":
-                        checkAry = ["19:00","19:30","19:45","20:00","20:30","22:00","23:00","3:00"];
-                        break;
-                    case "20":
-                        checkAry = ["20:00","20:30","22:00","23:00","3:00"];
-                        break;
-                    case "22":
-                        checkAry = ["22:00","23:00","3:00"];
-                        break;
-                    case "27":
-                        checkAry = ["3:00"];
-                        break;
-                }
-                var h24   = item.properties['H24'] ? item.properties['H24'] : item.properties['H24'];
-                var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
-                if(h24 === 'Y' || $.inArray(close, checkAry) >= 0) {
-                    return true;
-                }
-            };
-            return f(item,idx);
-        };
-        ninkagaiFeatures = ninkagaiFeatures.filter(filterfunc);
-    }
-    // 認可保育所：24時間
-    if(conditions['ninkagai24H']) {
+    // 24時間
+    if(conditions['24H']) {
         filterfunc = function (item,idx) {
             var h24 = item.properties['H24'] ? item.properties['H24'] : item.properties['H24'];
             if(h24 === 'Y') {
                 return true;
             }
         };
-        ninkagaiFeatures = ninkagaiFeatures.filter(filterfunc);
-    }
-    // 認可保育所：証明あり
-    if(conditions['ninkagaiShomei']) {
-        filterfunc = function (item,idx) {
-            var proof = item.properties['証明'] ? item.properties['証明'] : item.properties['Proof'];
-            if(proof === 'Y') {
-                return true;
-            }
-        };
-        ninkagaiFeatures = ninkagaiFeatures.filter(filterfunc);
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
     // console.log("[after]ninkagaiFeatures length:", ninkagaiFeatures.length);
 
@@ -211,8 +136,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
 
     // 戻り値の作成
     var features = [];
-    Array.prototype.push.apply(features, ninkaFeatures);
-    Array.prototype.push.apply(features, ninkagaiFeatures);
+    Array.prototype.push.apply(features, hoikuenFeatures);
     Array.prototype.push.apply(features, youchienFeatures);
     // console.log("getFilteredFeaturesGeoJson: return value: ", features.length);
     newGeoJson.features = features;

--- a/js/index.js
+++ b/js/index.js
@@ -343,48 +343,34 @@ $('#mainPage').on('pageshow', function() {
 		conditions = [];
 		ninka = ninkagai = kindergarten = false;
 
-		// 認可保育園
-		if($('#ninkaOpenTime option:selected').val() !== "") {
-			conditions['ninkaOpenTime'] = $('#ninkaOpenTime option:selected').val();
-			ninka = true;
+		// 保育園
+		if($('#OpenTime option:selected').val() !== "") {
+			conditions['OpenTime'] = $('#OpenTime option:selected').val();
+			ninka = ninkagai = true;
 		}
-		if($('#ninkaCloseTime option:selected').val() !== "") {
-			conditions['ninkaCloseTime'] = $('#ninkaCloseTime option:selected').val();
-			ninka = true;
+		if($('#CloseTime option:selected').val() !== "") {
+			conditions['CloseTime'] = $('#CloseTime option:selected').val();
+			ninka = ninkagai = true;
 		}
-		if($('#ninkaIchijiHoiku').prop('checked')) {
-			conditions['ninkaIchijiHoiku'] = 1;
-			ninka = true;
+		if($('#IchijiHoiku').prop('checked')) {
+			conditions['IchijiHoiku'] = 1;
+			ninka = ninkagai = true;
 		}
-		if($('#ninkaYakan').prop('checked')) {
-			conditions['ninkaYakan'] = 1;
-			ninka = true;
+		if($('#Yakan').prop('checked')) {
+			conditions['Yakan'] = 1;
+			ninka = ninkagai = true;
 		}
-		if($('#ninkaKyujitu').prop('checked')) {
-			conditions['ninkaKyujitu'] = 1;
-			ninka = true;
+		if($('#Kyujitu').prop('checked')) {
+			conditions['Kyujitu'] = 1;
+			ninka = ninkagai = true;
 		}
-		if($('#ninkaVacancy').prop('checked')) {
-			conditions['ninkaVacancy'] = 1;
-			ninka = true;
+		if($('#Vacancy').prop('checked')) {
+			conditions['Vacancy'] = 1;
+			ninka = ninkagai = true;
 		}
-
-		// 認可外
-		if($('#ninkagaiOpenTime option:selected').val() !== "") {
-			conditions['ninkagaiOpenTime'] = $('#ninkagaiOpenTime option:selected').val();
-			ninkagai = true;
-		}
-		if($('#ninkagaiCloseTime option:selected').val() !== "") {
-			conditions['ninkagaiCloseTime'] = $('#ninkagaiCloseTime option:selected').val();
-			ninkagai = true;
-		}
-		if($('#ninkagai24H').prop('checked')) {
-			conditions['ninkagai24H'] = 1;
-			ninkagai = true;
-		}
-		if($('#ninkagaiShomei').prop('checked')) {
-			conditions['ninkagaiShomei'] = 1;
-			ninkagai = true;
+		if($('#24H').prop('checked')) {
+			conditions['24H'] = 1;
+			ninka = ninkagai = true;
 		}
 
 		// 幼稚園


### PR DESCRIPTION
以下対応をしました。ご確認お願いします。

[検索条件]
・認可,認可外の区別を除去(一律メニュー)
・認可,認可外で重複する条件は一本化
・開園,終園時間について、どちらかにあればでまとめる
・開園は〜以前,終園は〜以降で統一

＊幼稚園部分については修正しておりません。