### PR TITLE
お気に入り一覧から削除機能(2つまで)

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,6 +183,7 @@
       			</form>
             <div class="ui-content">
             <a href="#compare-page" class="ui-btn ui-icon-bullets ui-btn-icon-left ui-corner-all ui-btn-b" id="compare-btn">比較する</a>
+            <p class="ui-btn ui-icon-bullets ui-icon-delete ui-btn-icon-left ui-corner-all ui-btn-b" id="delete-btn">お気に入りから外す</p>
             </div>
         	</div><!-- /content -->
         </div>

--- a/js/index.js
+++ b/js/index.js
@@ -525,29 +525,8 @@ $('#mainPage').on('pageshow', function() {
  */
 // 表示処理
 $('#favorite-list').on('pageshow', function() {
-	var favoriteList = filter.getFavoriteFeatures(nurseryFacilities);
-	var $items = $("#favorite-items");
-	$items.children().remove();
-	favoriteList.forEach(function(item, index){
-		var id = favoriteStore.getId(item);
-		var styleClass = "ui-btn ui-corner-all ui-btn-inherit ui-btn-icon-left ui-checkbox-on";
-		if (index === 0) {
-			styleClass += " ui-first-child";
-		}
-		if (index === favoriteList.length - 1) {
-			styleClass += " ui-last-child";
-		}
-		var element = "";
-		element += "<div class='ui-checkbox'>";
-		element += "  <label for='" + id + "' class='" + styleClass + "'>" + item.properties['Name'] + "</label>";
-		element += "  <input type='checkbox' value='" + id + "' id='" + id + "' " + (compareNurseries.indexOf(id) >= 0 ? "checked='checked'" : "") + ">";
-		element += "</div>"
-
-		$items.append(element);
-	});
-	$items.trigger('create');
-
-	onChangeCheckbox();
+	// お気に入り一覧作成
+	createFavoriteList();
 });
 
 // チェックボックス選択時
@@ -727,6 +706,33 @@ $('#delete-btn').on('tap', function() {
 			favoriteStore.removeFavorite(filter.getFeatureById(compareNurseries[i]));
 		}
 	}
-	// お気に入り一覧画面に反映するためreload
-	location.reload();
+	// お気に入り一覧再構築
+	createFavoriteList();
 });
+
+// お気に入り一覧作成
+function createFavoriteList() {
+	var favoriteList = filter.getFavoriteFeatures(nurseryFacilities);
+	var $items = $("#favorite-items");
+	$items.children().remove();
+	favoriteList.forEach(function(item, index){
+		var id = favoriteStore.getId(item);
+		var styleClass = "ui-btn ui-corner-all ui-btn-inherit ui-btn-icon-left ui-checkbox-on";
+		if (index === 0) {
+			styleClass += " ui-first-child";
+		}
+		if (index === favoriteList.length - 1) {
+			styleClass += " ui-last-child";
+		}
+		var element = "";
+		element += "<div class='ui-checkbox'>";
+		element += "  <label for='" + id + "' class='" + styleClass + "'>" + item.properties['Name'] + "</label>";
+		element += "  <input type='checkbox' value='" + id + "' id='" + id + "' " + (compareNurseries.indexOf(id) >= 0 ? "checked='checked'" : "") + ">";
+		element += "</div>"
+
+		$items.append(element);
+	});
+	$items.trigger('create');
+
+	onChangeCheckbox();
+}

--- a/js/index.js
+++ b/js/index.js
@@ -557,7 +557,16 @@ var onChangeCheckbox = function() {
 	  return $(this).val();
 	}).get();
 
-	if (compareNurseries.length >= 2) {
+    if (compareNurseries.length == 1) {
+		favoriteCheckboxes.each(function(){
+			$(this).removeClass("ui-state-disabled").removeClass("ui-state-active");
+			$(this).find(":checkbox").prop("disabled", false);
+		});
+		$("#compare-btn").addClass("ui-state-disabled");
+		$("#compare-btn").prop("disabled", true);
+		$("#delete-btn").removeClass("ui-state-disabled");
+		$("#delete-btn").prop("disabled", false);
+    } else if (compareNurseries.length >= 2) {
 		favoriteCheckboxes.each(function(){
 			var $checkbox = $(this).find(":checkbox");
 			if (!$checkbox.is(":checked")) {
@@ -574,8 +583,8 @@ var onChangeCheckbox = function() {
 			$(this).removeClass("ui-state-disabled").removeClass("ui-state-active");
 			$(this).find(":checkbox").prop("disabled", false);
 		});
-		$("#compare-btn").addClass("ui-state-disabled");
-		$("#compare-btn").prop("disabled", true);
+		$("#compare-btn, #delete-btn").addClass("ui-state-disabled");
+		$("#compare-btn, #delete-btn").prop("disabled", true);
 	}
 };
 $("#favorite-list").on("change", "#favorite-items .ui-checkbox :checkbox", onChangeCheckbox);
@@ -707,4 +716,17 @@ $('#compare-page').on('pageshow', function() {
 	content += compareDataDom("備考", nursery1["Remarks"], nursery2["Remarks"]);
 
 	$("#nursery-compare-body").html(content);
+});
+
+// お気に入りから外す
+$('#delete-btn').on('tap', function() {
+	var favoriteList = filter.getFavoriteFeatures(nurseryFacilities);
+	// チェックされた施設をお気に入りからremove
+	for(var i=0; i<favoriteList.length ; i++) {
+		if (compareNurseries[i] != null ) {
+			favoriteStore.removeFavorite(filter.getFeatureById(compareNurseries[i]));
+		}
+	}
+	// お気に入り一覧画面に反映するためreload
+	location.reload();
 });


### PR DESCRIPTION
お気に入り一覧画面で選択した施設を、
「お気に入りから外す」ボタンで、２つまで外せるように対応しました。

現行、比較機能の関係で２つ以上選択できないようになっておりますので、合わせております。

２つ以上一気に削除する必要がありましたら、やり方考えますのでお知らせください。

よろしくお願いします。