### PR TITLE
#6 認定こども園と事業所内保育所の表示対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,13 +128,23 @@
                         <input type="checkbox" id="Hoikuroom_auth" class="filtercb">
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+                        <label for="Kodomo">こども園</label>
+                        <input type="checkbox" id="Kodomo" class="filtercb">
+                        <label for="Shanai">事業所内保育所</label>
+                        <input type="checkbox" id="Shanai" class="filtercb">
+                    </fieldset>
+                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="Vacancy">空きあり（試用版。最新の空き状況ではありません）</label>
                         <input type="checkbox" id="Vacancy" class="filtercb">
                     </fieldset>
-                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <a href="#" data-rel="back" id="filterApply" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-check">条件適用</a>
-                        <a href="#" id="filterReset" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-delete">リセット</a>
-                    </fieldset>
+                    <div class="ui-grid-a">
+                      <div class="ui-block-a">
+                          <a href="#" data-rel="back" id="filterApply" class="ui-btn ui-corner-all ui-btn-b ui-btn-icon-left ui-icon-check">条件適用</a>
+                      </div>
+                      <div class="ui-block-b">
+                          <a href="#" id="filterReset" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-delete">リセット</a>
+                      </div>
+                    </div>
                 </div>
             </form>
         </div>

--- a/js/facilityfilter.js
+++ b/js/facilityfilter.js
@@ -147,6 +147,27 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
         };
         hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
     }
+    // 事業所内保育所
+    if(conditions['Shanai']) {
+        filterfunc = function (item,idx) {
+            var shanai = item.properties['Shanai'];
+            if(shanai === 'Y') {
+                return true;
+            }
+        };
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+    }
+    // こども園
+    if(conditions['Kodomo']) {
+        filterfunc = function (item,idx) {
+            var kodomo = item.properties['Kodomo'];
+            if(kodomo === 'Y') {
+                return true;
+            }
+        };
+        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        youchienFeatures = youchienFeatures.filter(filterfunc);
+    }
     // console.log("[after]ninkagaiFeatures length:", ninkagaiFeatures.length);
 
     // ----------------------------------------------------------------------

--- a/js/index.js
+++ b/js/index.js
@@ -382,6 +382,16 @@ $('#mainPage').on('pageshow', function() {
 			conditions['Hoikuroom_auth'] = 1;
 			ninkagai = true;
 		}
+		// こども園
+		if($('#Kodomo').prop('checked')) {
+			conditions['Kodomo'] = 1;
+			ninka = ninkagai = kindergarten = true;
+		}
+		// 事業所内保育所
+		if($('#Shanai').prop('checked')) {
+			conditions['Shanai'] = 1;
+			ninka = ninkagai = true;
+		}
 
 		// 幼稚園
 
@@ -615,6 +625,13 @@ $('#compare-page').on('pageshow', function() {
 	var content = '';
 	// 種別
 	content += compareDataDom("種別", nursery1["Type"], nursery2["Type"], "nursery-type");
+	// 施設種別
+	var kodomo1  = nursery1["Kodomo"] === 'Y' ? '認定こども園' : "";
+	var shanai1 = nursery1["Shanai"] === 'Y' ? '事業所内保育所' : "";
+	var kodomo2  = nursery2["Kodomo"] === 'Y' ? '認定こども園' : "";
+	var shanai2 = nursery2["Shanai"] === 'Y' ? '事業所内保育所' : "";
+	content += compareDataDom("施設種別", kodomo1+shanai1 || null, kodomo2+shanai2 || null, "nursery-type");
+
 	// 時間
 	var open1  = nursery1["Open"] || "";
 	var close1 = nursery1["Close"] || "";

--- a/js/papamamap.js
+++ b/js/papamamap.js
@@ -364,6 +364,18 @@ Papamamap.prototype.getPopupContent = function(feature)
         return null;
     };
 
+    var kodomo = feature.get('Kodomo');
+    var shanai = feature.get('Shanai');
+    if (kodomo === 'Y' || shanai === 'Y') {
+        content += '<tr>';
+        content += '<th>施設種別</th>';
+        content += '<td>';
+        content += kodomo === 'Y' ? '認定こども園 ' : '';
+        content += shanai === 'Y' ? '事業所内保育所 ' : '';
+        content += '</td>';
+        content += '</tr>';
+    }
+
     var open  = feature.get('開園時間') ? feature.get('開園時間') : feature.get('Open');
     var close = feature.get('終園時間') ? feature.get('終園時間') : feature.get('Close');
     if (open !=  null || close != null ) {


### PR DESCRIPTION
認定こども園と事業所内保育所の検索条件の追加及び表示対応

ついでに検索ダイアログの”条件適用”ボタン及び”リセット”ボタンのレイアウトが検索条件のボタンレイアウトと同じでわかりずらかったので、ボタンレイアウトを検索条件とは異なるレイアウトにしました。

またY, Nの項目についてはNの値も出す要件ですが、さすがに「認定こども園でない」「事業所内保育所でない」という情報はさすがに情報として不要だと思ったのでYの時だけ値を表示するようにしています。