### PR TITLE
お気に入り一覧から削除機能(方針変更後)

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -212,3 +212,50 @@ table.nursery-compare tbody tr.nursery-type td {
 table.nursery-compare tbody td {
 	width: 50%;
 }
+
+
+/* お気に入り削除 */
+div#favorite-list div.ui-controlgroup-controls div.ui-checkbox {
+	display:table;
+	width: 100%;
+}
+
+div#favorite-list div.ui-controlgroup-controls div.ui-checkbox div.delete-favorite-left {
+	display:table-cell;
+	width: 95%;
+	background-color: #f6f6f6;
+	border-bottom: 1px solid #ddd;
+}
+
+div#favorite-list div.ui-controlgroup-controls div.ui-checkbox div.delete-favorite-right {
+	display:table-cell;
+	width: 5%;
+	background-color: #f6f6f6;
+	border-bottom: 1px solid #ddd;
+}
+
+div#favorite-list div.ui-controlgroup-controls div.ui-checkbox div.delete-favorite-left label {
+	margin-bottom: 1px;
+	border: 0px;
+}
+
+div#favorite-list div.ui-controlgroup-controls div.ui-checkbox div.delete-favorite-right a {
+	border-style: none;
+}
+
+div#favorite-list div#popupBasic-popup div#popupBasic {
+	padding: 5%;
+}
+
+div#favorite-list div#popupBasic-popup div#popupBasic ul li {
+	display: inline-block;
+	width: 40%;
+}
+
+div#favorite-list div#popupBasic-popup div#popupBasic ul li a {
+	text-decoration: none;
+}
+
+div#favorite-list .ui-controlgroup-vertical .ui-controlgroup-controls .ui-btn.ui-last-child {
+    border-bottom-width: 0;
+}

--- a/index.html
+++ b/index.html
@@ -183,6 +183,7 @@
       			</form>
             <div class="ui-content">
             <a href="#compare-page" class="ui-btn ui-icon-bullets ui-btn-icon-left ui-corner-all ui-btn-b" id="compare-btn">比較する</a>
+            <p class="ui-btn ui-icon-bullets ui-icon-delete ui-btn-icon-left ui-corner-all ui-btn-b" id="delete-btn">お気に入りから外す</p>
             </div>
         	</div><!-- /content -->
         </div>

--- a/index.html
+++ b/index.html
@@ -183,7 +183,6 @@
       			</form>
             <div class="ui-content">
             <a href="#compare-page" class="ui-btn ui-icon-bullets ui-btn-icon-left ui-corner-all ui-btn-b" id="compare-btn">比較する</a>
-            <p class="ui-btn ui-icon-bullets ui-icon-delete ui-btn-icon-left ui-corner-all ui-btn-b" id="delete-btn">お気に入りから外す</p>
             </div>
         	</div><!-- /content -->
         </div>
@@ -212,6 +211,8 @@
             </table>
           </div>
         </div>
+
+        <input type='hidden' id='delete-flg' value=''>
 
         <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js" type="text/javascript"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-mobile/1.4.4/jquery.mobile.min.js" type="text/javascript"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -531,29 +531,8 @@ $('#mainPage').on('pageshow', function() {
  */
 // 表示処理
 $('#favorite-list').on('pageshow', function() {
-	var favoriteList = filter.getFavoriteFeatures(nurseryFacilities);
-	var $items = $("#favorite-items");
-	$items.children().remove();
-	favoriteList.forEach(function(item, index){
-		var id = favoriteStore.getId(item);
-		var styleClass = "ui-btn ui-corner-all ui-btn-inherit ui-btn-icon-left ui-checkbox-on";
-		if (index === 0) {
-			styleClass += " ui-first-child";
-		}
-		if (index === favoriteList.length - 1) {
-			styleClass += " ui-last-child";
-		}
-		var element = "";
-		element += "<div class='ui-checkbox'>";
-		element += "  <label for='" + id + "' class='" + styleClass + "'>" + item.properties['Name'] + "</label>";
-		element += "  <input type='checkbox' value='" + id + "' id='" + id + "' " + (compareNurseries.indexOf(id) >= 0 ? "checked='checked'" : "") + ">";
-		element += "</div>"
-
-		$items.append(element);
-	});
-	$items.trigger('create');
-
-	onChangeCheckbox();
+	// お気に入り一覧作成
+	createFavoriteList();
 });
 
 // チェックボックス選択時
@@ -746,6 +725,33 @@ $('#delete-btn').on('tap', function() {
 			favoriteStore.removeFavorite(filter.getFeatureById(compareNurseries[i]));
 		}
 	}
-	// お気に入り一覧画面に反映するためreload
-	location.reload();
+	// お気に入り一覧再構築
+	createFavoriteList();
 });
+
+// お気に入り一覧作成
+function createFavoriteList() {
+	var favoriteList = filter.getFavoriteFeatures(nurseryFacilities);
+	var $items = $("#favorite-items");
+	$items.children().remove();
+	favoriteList.forEach(function(item, index){
+		var id = favoriteStore.getId(item);
+		var styleClass = "ui-btn ui-corner-all ui-btn-inherit ui-btn-icon-left ui-checkbox-on";
+		if (index === 0) {
+			styleClass += " ui-first-child";
+		}
+		if (index === favoriteList.length - 1) {
+			styleClass += " ui-last-child";
+		}
+		var element = "";
+		element += "<div class='ui-checkbox'>";
+		element += "  <label for='" + id + "' class='" + styleClass + "'>" + item.properties['Name'] + "</label>";
+		element += "  <input type='checkbox' value='" + id + "' id='" + id + "' " + (compareNurseries.indexOf(id) >= 0 ? "checked='checked'" : "") + ">";
+		element += "</div>"
+
+		$items.append(element);
+	});
+	$items.trigger('create');
+
+	onChangeCheckbox();
+}

--- a/js/index.js
+++ b/js/index.js
@@ -549,7 +549,7 @@ var onChangeCheckbox = function() {
 	  return $(this).val();
 	}).get();
 
-    if (compareNurseries.length >= 2) {
+	if (compareNurseries.length >= 2) {
 		favoriteCheckboxes.each(function(){
 			var $checkbox = $(this).find(":checkbox");
 			if (!$checkbox.is(":checked")) {

--- a/js/index.js
+++ b/js/index.js
@@ -563,7 +563,16 @@ var onChangeCheckbox = function() {
 	  return $(this).val();
 	}).get();
 
-	if (compareNurseries.length >= 2) {
+    if (compareNurseries.length == 1) {
+		favoriteCheckboxes.each(function(){
+			$(this).removeClass("ui-state-disabled").removeClass("ui-state-active");
+			$(this).find(":checkbox").prop("disabled", false);
+		});
+		$("#compare-btn").addClass("ui-state-disabled");
+		$("#compare-btn").prop("disabled", true);
+		$("#delete-btn").removeClass("ui-state-disabled");
+		$("#delete-btn").prop("disabled", false);
+    } else if (compareNurseries.length >= 2) {
 		favoriteCheckboxes.each(function(){
 			var $checkbox = $(this).find(":checkbox");
 			if (!$checkbox.is(":checked")) {
@@ -580,8 +589,8 @@ var onChangeCheckbox = function() {
 			$(this).removeClass("ui-state-disabled").removeClass("ui-state-active");
 			$(this).find(":checkbox").prop("disabled", false);
 		});
-		$("#compare-btn").addClass("ui-state-disabled");
-		$("#compare-btn").prop("disabled", true);
+		$("#compare-btn, #delete-btn").addClass("ui-state-disabled");
+		$("#compare-btn, #delete-btn").prop("disabled", true);
 	}
 };
 $("#favorite-list").on("change", "#favorite-items .ui-checkbox :checkbox", onChangeCheckbox);
@@ -726,4 +735,17 @@ $('#compare-page').on('pageshow', function() {
 	content += compareDataDom("備考", nursery1["Remarks"], nursery2["Remarks"]);
 
 	$("#nursery-compare-body").html(content);
+});
+
+// お気に入りから外す
+$('#delete-btn').on('tap', function() {
+	var favoriteList = filter.getFavoriteFeatures(nurseryFacilities);
+	// チェックされた施設をお気に入りからremove
+	for(var i=0; i<favoriteList.length ; i++) {
+		if (compareNurseries[i] != null ) {
+			favoriteStore.removeFavorite(filter.getFeatureById(compareNurseries[i]));
+		}
+	}
+	// お気に入り一覧画面に反映するためreload
+	location.reload();
 });


### PR DESCRIPTION
お気に入り一覧から削除を、
「　リストの右側の×ボタン →　ポップアップ　→　はい選択　→　削除　」の方針に変更しました。
削除後の、リストと地図上の更新を一気にやりたかったのですが、方法が見つからなかったため、
リストはお気に入り画面で更新。
地図は削除があった時のみ、メイン画面に戻った際ページreloadで更新しています。
他にいい方法がご教示頂ければと思います。
よろしくお願いします。

・元の内容
https://github.com/codeforchiba/papamama/pull/18