### PR TITLE
詳細画面のお気に入りボタンの位置を下に移動

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,11 +79,11 @@
             <div id="popup" data-role="popup" data-theme="a" class="ol-popup" style="max-height: 200px;">
                 <a href="#" id="popup-closer" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-btn-a ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>
                 <div id="popup-title" data-role="header" data-theme="a"></div>
+                <div id="popup-content" role="main"></div>
                 <div id="popup-nav">
                   <a id="add-favorite" href="#" class="ui-btn ui-icon-star ui-btn-icon-left ui-mini">お気に入り登録する</a>
                   <a id="remove-favorite" href="#" class="ui-btn ui-icon-star ui-btn-icon-left ui-mini ui-state-active">お気に入り登録中</a>
                 </div>
-                <div id="popup-content" role="main"></div>
             </div>
         </div>
 


### PR DESCRIPTION
詳細画面のお気に入りボタンの位置を、メインコンテンツの下に変更しました。
よろしくお願いします。