### PR TITLE
幼稚園検索追加,レイヤの定義変更

### DIFF
--- a/js/facilityfilter.js
+++ b/js/facilityfilter.js
@@ -18,24 +18,16 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     };
     // console.log("getFilteredFeaturesGeoJson");
 
-    // 保育園の検索元データを取得
-    var hoikuenFeatures = [];
+    // 保育園,幼稚園の検索元データを取得
+    var Features = [];
     _features = nurseryFacilities.features.filter(function (item,idx) {
             var type = item.properties['種別'] ? item.properties['種別'] : item.properties['Type'];
-            if(type == "認可保育所" || type == "認可外") return true;
+            if(type == "認可保育所" || type == "認可外" || type == "幼稚園") return true;
         });
-    Array.prototype.push.apply(hoikuenFeatures, _features);
-
-    // 幼稚園の検索元データを取得
-    var youchienFeatures = [];
-    _features = nurseryFacilities.features.filter(function (item,idx) {
-            var type = item.properties['種別'] ? item.properties['種別'] : item.properties['Type'];
-            if(type == "幼稚園") return true;
-        });
-    Array.prototype.push.apply(youchienFeatures, _features);
+    Array.prototype.push.apply(Features, _features);
 
     // ----------------------------------------------------------------------
-    // 保育園向けフィルター
+    // 保育園,幼稚園向けフィルター
     // ----------------------------------------------------------------------
     // 開園時間
     // console.log("[before]ninkaFeatures length:", ninkaFeatures.length);
@@ -44,13 +36,15 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
             f = function (item,idx) {
                 var _time = conditions['OpenTime'];
                 var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
-                if(open <= _time) {
-                    return true;
+                if( open != null) {
+                    if(open <= _time) {
+                        return true;
+                    }
                 }
             };
             return f(item,idx);
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 終園時間
     if(conditions['CloseTime']) {
@@ -58,22 +52,23 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
             f = function (item,idx) {
                 var _time = conditions['CloseTime'];
                 var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
+                if( close != null) {
+                    // 終園時間が0時or翌日の場合は、24時間プラス
+                    if(close == '0:00' || close.substr(0,1) == '翌') {
+                        var index = close.indexOf('：');
+                        var hour = Number(close.substr(1,index-1)) + 24;
+                        var minute = close.substr(index+1);
+                        close = hour + ':' + minute;
+                    }
 
-                // 終園時間が0時or翌日の場合は、24時間プラス
-                if(close == '0:00' || close.substr(0,1) == '翌') {
-                    var index = close.indexOf('：');
-                    var hour = Number(close.substr(1,index-1)) + 24;
-                    var minute = close.substr(index+1);
-                    close = hour + ':' + minute;
-                }
-
-                if(close >= _time) {
-                    return true;
+                    if(close >= _time) {
+                        return true;
+                    }
                 }
             };
             return f(item,idx);
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 一時保育
     if(conditions['IchijiHoiku']) {
@@ -83,7 +78,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 夜間
     if(conditions['Yakan']) {
@@ -93,7 +88,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 休日
     if(conditions['Kyujitu']) {
@@ -103,7 +98,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 空き状況
     if(conditions['Vacancy']) {
@@ -113,7 +108,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // console.log("[after]ninkaFeatures length:", ninkaFeatures.length);
 
@@ -125,7 +120,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 先取りプロジェクト認定あり
     if(conditions['Sakidori_auth']) {
@@ -135,7 +130,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 保育ルーム認定あり
     if(conditions['Hoikuroom_auth']) {
@@ -145,7 +140,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // 事業所内保育所
     if(conditions['Shanai']) {
@@ -155,7 +150,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // こども園
     if(conditions['Kodomo']) {
@@ -165,20 +160,12 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
                 return true;
             }
         };
-        hoikuenFeatures = hoikuenFeatures.filter(filterfunc);
-        youchienFeatures = youchienFeatures.filter(filterfunc);
+        Features = Features.filter(filterfunc);
     }
     // console.log("[after]ninkagaiFeatures length:", ninkagaiFeatures.length);
-
-    // ----------------------------------------------------------------------
-    // 幼稚園向けフィルター
-    // ----------------------------------------------------------------------
-    // まだ用意しない
-
     // 戻り値の作成
     var features = [];
-    Array.prototype.push.apply(features, hoikuenFeatures);
-    Array.prototype.push.apply(features, youchienFeatures);
+    Array.prototype.push.apply(features, Features);
     // console.log("getFilteredFeaturesGeoJson: return value: ", features.length);
     newGeoJson.features = features;
     return newGeoJson;

--- a/js/index.js
+++ b/js/index.js
@@ -348,59 +348,45 @@ $('#mainPage').on('pageshow', function() {
 	$('#filterApply').click(function(evt){
 		// 条件作成処理
 		conditions = [];
-		ninka = ninkagai = kindergarten = false;
 
 		// 保育園
 		if($('#OpenTime option:selected').val() !== "") {
 			conditions['OpenTime'] = $('#OpenTime option:selected').val();
-			ninka = ninkagai = true;
 		}
 		if($('#CloseTime option:selected').val() !== "") {
 			conditions['CloseTime'] = $('#CloseTime option:selected').val();
-			ninka = ninkagai = true;
 		}
 		if($('#IchijiHoiku').prop('checked')) {
 			conditions['IchijiHoiku'] = 1;
-			ninka = ninkagai = true;
 		}
 		if($('#Yakan').prop('checked')) {
 			conditions['Yakan'] = 1;
-			ninka = ninkagai = true;
 		}
 		if($('#Kyujitu').prop('checked')) {
 			conditions['Kyujitu'] = 1;
-			ninka = ninkagai = true;
 		}
 		if($('#Vacancy').prop('checked')) {
 			conditions['Vacancy'] = 1;
-			ninka = ninkagai = true;
 		}
 		if($('#24H').prop('checked')) {
 			conditions['24H'] = 1;
-			ninka = ninkagai = true;
 		}
 		// 先取りプロジェクト認定
 		if($('#Sakidori_auth').prop('checked')) {
 			conditions['Sakidori_auth'] = 1;
-			ninkagai = true;
 		}
 		// 保育ルーム認定
 		if($('#Hoikuroom_auth').prop('checked')) {
 			conditions['Hoikuroom_auth'] = 1;
-			ninkagai = true;
 		}
 		// こども園
 		if($('#Kodomo').prop('checked')) {
 			conditions['Kodomo'] = 1;
-			ninka = ninkagai = kindergarten = true;
 		}
 		// 事業所内保育所
 		if($('#Shanai').prop('checked')) {
 			conditions['Shanai'] = 1;
-			ninka = ninkagai = true;
 		}
-
-		// 幼稚園
 
 		// フィルター適用時
 		if(Object.keys(conditions).length > 0) {
@@ -410,11 +396,7 @@ $('#mainPage').on('pageshow', function() {
 		} else {
 			papamamap.addNurseryFacilitiesLayer(nurseryFacilities);
 			$('#btnFilter').css('background-color', '#f6f6f6');
-			ninka = ninkagai = kindergarten = true;
 		}
-
-		// レイヤー表示状態によって施設の表示を切り替える
-		updateLayerStatus({ninka: ninka, ninkagai: ninkagai, kindergarten: kindergarten});
 	});
 
 	// 絞込条件のリセット


### PR DESCRIPTION
以下対応しました。よろしくお願いします。
・検索ロジックに幼稚園を追加
・検索条件適用時、データの有無に関わらず、レイヤの認可,認可外,幼は選択状態
・終園時間でnullでも時間比較をしていたため、null以外の時というロジッック追加