### PR TITLE
ol.Attributionをv3.1.0以降の指定方法に変更

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -58,7 +58,7 @@ var mapServerList = {
 		source: new ol.source.OSM({
 			url: "http://{a-c}.tile.thunderforest.com/transport/{z}/{x}/{y}.png",
 			attributions: [
-				ol.source.OSM.DATA_ATTRIBUTION,
+				ol.source.OSM.ATTRIBUTION,
 				new ol.Attribution({html: "Tiles courtesy of <a href='http://www.thunderforest.com/' target='_blank'>Andy Allan</a>"})
 			]
 		})


### PR DESCRIPTION
ol3のv3.1.0以降から、
> ol.source.OSM.DATA_ATTRIBUTION

が、以下に変更になったことから、エラーになっておりました。

>ol.source.OSM.ATTRIBUTION 

https://openlayers.org/en/latest/apidoc/ol.Attribution.html