### PR TITLE
#69 勝手にお気に入りに登録される。不具合解消

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -200,23 +200,17 @@ $('#mainPage').on('pageshow', function() {
 				$addFavoriteBtn.show();
 				$removeFavoriteBtn.hide();
 			}
-			$addFavoriteBtn.on('click',function(){
+			$addFavoriteBtn.off('click').on('click',function(){
 				favoriteStore.addFavorite(feature);
 				papamamap.updateNurseryStyle(feature, null);
 				$addFavoriteBtn.hide();
 				$removeFavoriteBtn.show();
-
-				$addFavoriteBtn.off('click');
-				$removeFavoriteBtn.off('click');
 			});
-			$removeFavoriteBtn.on('click',function(){
+			$removeFavoriteBtn.off('click').on('click',function(){
 				favoriteStore.removeFavorite(feature);
 				papamamap.updateNurseryStyle(feature, null);
 				$addFavoriteBtn.show();
 				$removeFavoriteBtn.hide();
-
-				$addFavoriteBtn.off('click');
-				$removeFavoriteBtn.off('click');
 			});
 
 			var height = $('#popup').css('max-height', '').height();


### PR DESCRIPTION
イベント解除のタイミングがお気に入りボタン押下時になっていたため、
お気にりボタン押下せずに他の園を参照するとイベントが残り続けていた。

対応としてイベント登録するタイミングで一度イベントをクリアしてから登録し直すように修正