### PR TITLE
説明ページ中のマップ名称統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
 
         <div data-role="popup" data-history="false" id="helpDialog" data-theme="a" class="ui-corner-all ui-icon-delete ui-btn-left">
             <a href="#" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-btn-a ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>
-            <div data-role="header" data-theme="a">千葉市保育園マップについて</div>
+            <div data-role="header" data-theme="a">ちば保育園マップについて</div>
             <div data-role="main" class="main">
               <section>
                 保育園（認可保育所、認可外保育所）、幼稚園を地図に表示をしました。<br><br>
@@ -212,7 +212,7 @@
                         </tr>
                         <tr>
                           <th class="normal">フィードバックする</th>
-                          <td>「千葉市保育園マップ」について意見を入力できます。</td>
+                          <td>「ちば保育園マップ」について意見を入力できます。</td>
                         </tr>
                       </tbody>
                     </table>
@@ -381,12 +381,12 @@
                   <h3>ご利用上のご注意</h3>
                 </header>
                 <div>
-                  「千葉市保育園マップ」は、千葉市が提供するオープンデータを元に、Code for Chibaが提供しています。<br>
+                  「ちば保育園マップ」は、千葉市が提供するオープンデータを元に、Code for Chibaが提供しています。<br>
 保育所などのデータについては千葉市の職員の方々、サービスはCode for Chibaのメンバーが極力間違いがないようにしておりますが、瑕疵（かし）やバグがないことは保証しておりません。<br>
 もしデータの間違いやバグなどにお気づきの際はメニューの「フィードバックする」からお伝えいただけると幸いです。<br>
 また、利用者の方々にはあらかじめ通知することなくサービスの内容や仕様を変更したり、提供を停止したり中止したりする場合がありますがご了承ください。<br>
 <br>
-「千葉市保育園マップ」は、Code for Sapporo の開発したさっぽろ保育園マップを母体として開発されました。<br>
+「ちば保育園マップ」は、Code for Sapporo の開発したさっぽろ保育園マップを母体として開発されました。<br>
 <br>
 <a href="https://github.com/codeforchiba/papamama" target="_blank">詳しくはこちら</a>
                 </div>


### PR DESCRIPTION
説明ページ中のマップ名称を、「ちば保育園マップ」に統一しました。
よろしくお願いします。