### PR TITLE
githubページへのリンク削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,14 +381,14 @@
                   <h3>ご利用上のご注意</h3>
                 </header>
                 <div>
-                  「ちば保育園マップ」は、千葉市が提供するオープンデータを元に、Code for Chibaが提供しています。<br>
-保育所などのデータについては千葉市の職員の方々、サービスはCode for Chibaのメンバーが極力間違いがないようにしておりますが、瑕疵（かし）やバグがないことは保証しておりません。<br>
+                  「ちば保育園マップ」は、千葉市が提供するオープンデータを元に、<a href="http://code4chiba.org/" target="_blank">Code for Chiba</a>が提供しています。<br>
+保育所などのデータについては千葉市の職員の方々、サービスは<a href="http://code4chiba.org/" target="_blank">Code for Chiba</a>のメンバーが極力間違いがないようにしておりますが、瑕疵（かし）やバグがないことは保証しておりません。<br>
 もしデータの間違いやバグなどにお気づきの際はメニューの「フィードバックする」からお伝えいただけると幸いです。<br>
 また、利用者の方々にはあらかじめ通知することなくサービスの内容や仕様を変更したり、提供を停止したり中止したりする場合がありますがご了承ください。<br>
 <br>
 「ちば保育園マップ」は、Code for Sapporo の開発したさっぽろ保育園マップを母体として開発されました。<br>
 <br>
-<a href="https://github.com/codeforchiba/papamama" target="_blank">詳しくはこちら</a>
+<a href="https://github.com/codeforchiba/papamama" target="_blank">githubのページ</a>
                 </div>
               </section>
             </div>


### PR DESCRIPTION
説明ページ最下部の、「詳しくはこちら(githubページへのリンク)」を削除しました。
よろしくお願いします。